### PR TITLE
Automate Annotation Macro and Connection Cypher

### DIFF
--- a/dataset/cell_race_high_rust_001.rs
+++ b/dataset/cell_race_high_rust_001.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)] // The vulnerability exists despite no unsafe code
+// The vulnerability exists despite no unsafe code.
 
 // Minimal mocks for missing crates
 mod abox {

--- a/src/backend/AnnotationMacro.rs
+++ b/src/backend/AnnotationMacro.rs
@@ -1,0 +1,48 @@
+extern "C" {
+    #[link_name = "llvm.ptr.annotation.p0"]
+    fn llvm_ptr_annotation_p0(
+        val: *const u8,
+        annotation: *const u8,
+        file: *const u8,
+        line: i32,
+    ) -> *const u8;
+}
+
+#[macro_export]
+macro_rules! annotate {
+    // Regular declarations
+    ($var:ident = $value:expr, $annotation:literal, $line:expr) => {
+        let $var = $value;
+        annotate!(@call_llvm_annotate $var, $annotation, $line);
+    };
+
+    // Regular dec. with type:
+    ($var:ident : $_:ty = $value:expr, $annotation:literal, $line:expr) => {
+        let $var = $value;
+        annotate!(@call_llvm_annotate $var, $annotation, $line);
+    };
+
+    // Mutables
+    (mut $var:ident = $value:expr, $annotation:literal, $line:expr) => {
+        let $var = $value;
+        annotate!(@call_llvm_annotate $var, $annotation, $line);
+    };
+
+    // Mutables dec. with type:
+    (mut $var:ident : $_:ty = $value:expr, $annotation:literal, $line:expr) => {
+        let $var = $value;
+        annotate!(@call_llvm_annotate $var, $annotation, $line);
+    };
+
+    // Shared annotation logic:
+    (@call_llvm_annotate $var:ident, $annotation:literal, $line:expr) => {
+        unsafe {
+            llvm_ptr_annotation_p0(
+                &$var as *const _ as *const u8,
+                concat!($annotation, "\0").as_ptr(),
+                file!().as_ptr(),
+                $line as i32,
+            );
+        }
+    }
+}

--- a/src/backend/AnnotationMacro.rs
+++ b/src/backend/AnnotationMacro.rs
@@ -24,13 +24,13 @@ macro_rules! annotate {
 
     // Mutables
     (mut $var:ident = $value:expr, $annotation:literal, $line:expr) => {
-        let $var = $value;
+        let mut $var = $value;
         annotate!(@call_llvm_annotate $var, $annotation, $line);
     };
 
     // Mutables dec. with type:
     (mut $var:ident : $_:ty = $value:expr, $annotation:literal, $line:expr) => {
-        let $var = $value;
+        let mut $var = $value;
         annotate!(@call_llvm_annotate $var, $annotation, $line);
     };
 

--- a/src/backend/AnnotationMacro.rs
+++ b/src/backend/AnnotationMacro.rs
@@ -41,7 +41,7 @@ macro_rules! annotate {
                 &$var as *const _ as *const u8,
                 concat!($annotation, "\0").as_ptr(),
                 file!().as_ptr(),
-                $line as i32,
+                ($line-2) as i32,
             );
         }
     }

--- a/src/backend/ConnectionCypher.py
+++ b/src/backend/ConnectionCypher.py
@@ -93,4 +93,8 @@ SET variable.annotation=annotation.name,
     variable.line_number = annotation.line_number
 
 MERGE (annotation)-[:ANNOTATE]->(variable)
+WITH annotation AS _
+
+MATCH (a: Annotation)
+RETURN count(DISTINCT a)
 """

--- a/src/backend/ConnectionCypher.py
+++ b/src/backend/ConnectionCypher.py
@@ -1,0 +1,96 @@
+"""
+After committing the annotated IR to Neo4J, the nodes we are annotating remains
+disconnected from any data involving the annotation. This post-process cypher
+connects those nodes and then creates new properties and a new "Annotation" node.
+"""
+
+CONNECTION_CYPHER =\
+"""
+// Match the reference containing the function call
+// This is so we can use the EOG to label argumentIndex (which, by default, are 0 at the start).
+MATCH(r:Reference WHERE r.fullName CONTAINS "llvm.ptr.annotation.p0")
+WITH r
+
+// Before anything, we run through the EOG from 1->5 (llvm.ptr.annotation.p0 has 4 arguments)
+// To make operations easier later in this cypher, we adjust the argumentIndex property which
+// was not properly saved from CPG->Neo4J.
+MATCH arg_path = (r)-[:EOG*1..4]->(_)
+FOREACH (arg in nodes(arg_path) |
+    SET arg.argumentIndex=[x IN range(0, 4) WHERE nodes(arg_path)[x]=arg][0]-1
+)
+WITH arg_path
+
+//
+// Argument Traversal:
+// Traversing annotation argument until literal is reached.
+//  : <n> is the CallExpression for llvm.ptr.annotation.p0.
+//  : <arg_path> is the EOG path from <n>'s reference to the final argument.
+//
+MATCH(n:CallExpression {fullName: "llvm.ptr.annotation.p0i8.p0i8"})
+
+// Some arguments (like line number) will start as a literal.
+// If that's the case, we're done with those and we save them within <args>.
+MATCH (n)-[:OPERATOR_ARGUMENTS]->(args WHERE args:Literal AND NOT args.code CONTAINS "null")
+
+// Now, we get the second set of arguments which were NOT literals as <others>.
+MATCH (n)-[:OPERATOR_ARGUMENTS]->(others WHERE NOT others:Literal AND others.argumentIndex > 0)
+
+// To make things easier for the next call, I move on to the reference and copy that argIndex property.
+MATCH (others)-[:REFERS_TO]->(reference)
+SET reference.argumentIndex=others.argumentIndex
+WITH n, reference, args
+
+// Follow the path from the annotation's argument's reference -> the literal.
+CALL apoc.path.expandConfig(reference, {
+    relationshipFilter: ">EOG|>REFERS_TO", // follow eog or refers_to, 
+    // labelFilter: "/ConstructExpression",
+    labelFilter: "-FunctionDeclaration|-CastExpression|/Literal",
+    minLevel: 1
+})
+YIELD path
+
+// Next, set the argumentIndex on the literal.
+WITH path, n, args, LAST(nodes(path)) AS literal, HEAD(nodes(path)) AS start
+SET literal.argumentIndex=start.argumentIndex
+
+// Combine literals into 1 list and sort by argumentIndex
+WITH n, COLLECT(DISTINCT literal) + COLLECT(DISTINCT args) AS literals
+UNWIND literals as item
+ORDER BY item.argumentIndex
+WITH n, COLLECT(item) AS literals
+
+//
+// Annotation Node
+//  : <n> remains in scope
+//  : <literals> is now a list of all annotation related literals ordered by argumentIndex.
+//       <literals> = [<annotation name>, <filename>, <line number>]
+//
+MERGE(annotation:Annotation {
+    name: literals[0].value,
+    filename: literals[1].value,
+    line_number: literals[2].value
+})
+
+// SCOPE CHANGE
+// : <n>
+// : <annotation>
+WITH n, annotation
+
+// Find the node that we are annotating (and then the actual VariableDeclaration of it)
+// No need for APOC call here because we're only actually reaching two direct paths.
+MATCH (n)-[:OPERATOR_ARGUMENTS]->(_ {argumentIndex: 0})-[:REFERS_TO]-(register)
+
+// I use APOC here only for speed purposes.
+CALL apoc.path.subgraphNodes(register, {
+    relationshipFilter: "<DFG",
+    labelFilter: "/VariableDeclaration"
+})
+YIELD node AS variable
+
+// Set properties on the variable itself
+SET variable.annotation=annotation.name,
+    variable.filename = annotation.filename,
+    variable.line_number = annotation.line_number
+
+MERGE (annotation)-[:ANNOTATE]->(variable)
+"""

--- a/src/backend/handler.py
+++ b/src/backend/handler.py
@@ -250,8 +250,6 @@ def link_annotation_nodes() -> str:
 
     with driver.session() as session:
         result = session.run(CONNECTION_CYPHER)
-        for n in result:
-            print (n.keys(), n.values())
         return "[SUCCESS] Annotation Link success!"
 
     return "[FAILED] Annotation Link: Could not properly run link cypher."


### PR DESCRIPTION
Merges `macro-process-automation` branch into `main`. 
## Wrapping Variable Declarations
Variable declarations are automatically wrapped using the `annotate!` macro.

**Snippet from: `src/backend/handler.py`.** 
`annotate!` is wrapped and properly formatted around `let` declarations. I use regex to match the declarations. Things like `if let` are ignored.

```python
# Matches keywords before let. Those are filtered out.
COMMON_LET = r"(?P<keyword>\b(?:if|for|while|loop)\b(?:\s+)?)?\blet"

VAR_DECLARATION_PATTERNS = [
    r'(\s*(mut\s*(\w+))\s*:\s*[^=]+?\s*=\s*(?!\s*[\(\{]).+?);', # Typed Mutable
    r'(\s*(mut\s*(\w+))\s*=\s*(?!\s*[\(\{]).+?);', # Mutable
    r'(\s*((\w+))\s*:\s*[^=]+?\s*=\s*(?!\s*[\(\{]).+?);', # Typed Immutable
    r'(\s*((\w+))\s*=\s*(?!\s*[\(\{]).+?);' # Immutable
]
```
## Connecting LLVM Annotations -> Registers
When the `annotate!` macro is done, it creates a new `llvm.ptr.annotation.p0` node. The first argument of this function is what is being annotated, but Neo4J doesn't know that. After processing the everything, the **[connection cypher](https://www.notion.so/Updated-Connection-Cypher-Other-Information-25e313b51b7780f39c8ec83f7690a2c0?source=copy_link#25e313b51b77800d99bddcbbf8e667b7)** is automatically run to properly link within Neo4J.

## Using Annotations for Data Flow
Since the declarations themselves are annotated, we can use that to map the dataflow to/from each other. (Ernesto [created a query earlier](https://www.notion.so/Updated-Connection-Cypher-Other-Information-25e313b51b7780f39c8ec83f7690a2c0?source=copy_link#26b313b51b778092a43edd19a55e4e04). I ended up doing it within APOC since it was much faster and easier to read).
```
MATCH (n: VariableDeclaration {annotation: "SENDABLE_PTR"})
MATCH (raw: VariableDeclaration {annotation: "INPUT_RAW_DATA"})
MATCH (data: VariableDeclaration {annotation: "INPUT_DATA"})

// Dataflow Graph from INPUT_DATA -> INPUT_RAW_DATA and SENDABLE_PTr:
CALL apoc.path.expandConfig(data, {
    relationshipFilter: "DFG|REFERS_TO",
    minLevel: 1,
    maxLevel: 15,
    dfs: true,
    terminatorNodes: [n, raw]
})
YIELD path

// From n -> UnaryOperator/BinaryOperator
CALL apoc.path.expandConfig(n,{
    relationshipFilter: "DFG",
    labelFilter: ">UnaryOperator|>BinaryOperator",
    minLevel: 1,
    maxLevel: 12,
    dfs: true
})
YIELD path AS sendablePtrFlow
RETURN sendablePtrFlow
``` 
____

(More info on the **[Notion page](https://www.notion.so/Updated-Connection-Cypher-Other-Information-25e313b51b7780f39c8ec83f7690a2c0?source=copy_link)**)